### PR TITLE
Added Ctrl+R, Ctrl+R Rename Refactoring keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
             {
                 "key": "ctrl+alt+l",
                 "command": "workbench.view.explorer"
+            },
+            {
+                "key": "ctrl+r ctrl+r",
+                "command": "editor.action.rename",
+                "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
             }
         ]
     },


### PR DESCRIPTION
Closes #1.

Behaves just like the default F2 keybinding.

```
{ "key": "f2",                   
 "command": "editor.action.rename",
  "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly" }
```