### PR TITLE
add navigateBack and navigateForward keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,14 @@
                 "key": "ctrl+k ctrl+m",
                 "command": "editor.foldAll",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+-",
+                "command": "workbench.action.navigateBack"
+            },
+            {
+                "key": "ctrl+shift+-",
+                "command": "workbench.action.navigateForward"
             }
         ]
     },


### PR DESCRIPTION
VS Code default zoomOut still available using ctrl+numpad_subtract