### PR TITLE
Add Shift+Alt+Enter for zen mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,10 @@
                 "when": "editorTextFocus"
             },
             {
+                "key": "shift+alt+enter",
+                "command": "workbench.action.toggleZenMode"
+            },
+            {
                 "key": "ctrl+f4",
                 "command": "workbench.action.closeActiveEditor"
             }


### PR DESCRIPTION
In Visual Studio you can toggle between fullscreen mode by pressing Shift+Alt+Enter. This is the same thing like zen mode in VS Code.