### PR TITLE
Ctrl Right & Ctrl Shift Right Caret Position

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,16 @@
             {
                 "key": "ctrl+d",
                 "command": "editor.action.copyLinesDownAction"
+            },
+            {
+                "key": "ctrl+right",
+                "command": "cursorWordStartRight",
+                "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+shift+right",
+                "command": "cursorWordStartRightSelect",
+                "when": "editorTextFocus"
             }
         ]
     },


### PR DESCRIPTION
In Visual Studio, when you press Ctrl + right your caret moves to the start of the next word, while in VS Code, it moves to the end of the current word.