### PR TITLE
Add New File Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,11 @@
                 "command": "workbench.view.explorer"
             },
             {
+                "key": "ctrl+shift+a",
+                "command": "explorer.newFile",
+                "when": "explorerViewletFocus" }
+            },
+            {
                 "key": "ctrl+r ctrl+r",
                 "command": "editor.action.rename",
                 "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"


### PR DESCRIPTION
Usual workflow in Visual Studio is to open explorer using `ctrl+alt+l` and then create a new file in selected directory using [fwefe] `ctrl+shift+a`. 
Current mapping was missing `ctrl+shift+a` shortcut, which was added according to instructions [here](https://stackoverflow.com/questions/39599514/vs-code-add-a-new-file-under-the-selected-working-directory).